### PR TITLE
clean up warnings; customizable parser (#14)

### DIFF
--- a/.github/workflows/aunit_tests.yml
+++ b/.github/workflows/aunit_tests.yml
@@ -1,6 +1,6 @@
 name: SimpleSerialShell unit test check
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
   build:
@@ -13,7 +13,8 @@ jobs:
     - name: Setup
       run: |
         cd ..
-        git clone https://github.com/bxparks/UnixHostDuino
+        #(old) git clone https://github.com/bxparks/UnixHostDuino
+        git clone https://github.com/bxparks/EpoxyDuino
         git clone https://github.com/bxparks/AUnit
     #- name: Verify examples
       #run: |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Sending "echo Hello World!" returns "Hello World!" on the serial monitor.
 * **IdentifyTheSketch** -- Example provides an "id?" query which reports the filename and build date of the sketch running.  
 Useful if you forgot what was loaded on this board.
 
+### Alternate Tokenizers
+
+By default, shell input is tokenized using the UNIX standard strtok_r(3) function.  This splits user input into space-delimited tokens. There may be applications where a more sophisticated tokenizer is desired. Quoted tokens with internal spaces, for example.  The setTokenizer() method can be used to install a custom tokenizer.
+
+A demonstration of this feature can be seen [here](examples/AlternateTokenizer).
+
 ### Tips
 
 * "help" is a built-in command.  It lists what is available.
@@ -72,6 +78,10 @@ a custom stream.
 * To make it easy to switch commands to a different connection, I recommend always
 sending command output to the shell
 (rather than straight to Serial for example).  For example I use `shell.println("motor is off");`
+
+* Please note that the list of commands is shared between instances
+of the SimpleSerialShell (via a static).  The fact that the addCommand() method
+is non-static can be slighly misleading in this regard.
 
 ### Notes
 

--- a/examples/AlternateTokenizer/AlternateTokenizer.ino
+++ b/examples/AlternateTokenizer/AlternateTokenizer.ino
@@ -1,0 +1,143 @@
+/**
+ * @file AlternateTokenizer.ino
+ * @author brucemack
+ * @version 0.1
+ * @date 2021-12-29
+ * 
+ * @copyright Copyright (c) 2021
+ * 
+ * A demonstration of the SimpleSerialShell using an alternate tokenizer that 
+ * supports the use of quoted strings.
+ * 
+ * Depends on https://github.com/philj404/SimpleSerialShell.
+ * 
+ * Here is an example run:
+ * 
+ * echo test
+ * Argument 1: [test]
+ * echo test test2
+ * Argument 1: [test]
+ * Argument 2: [test2]
+ * echo test "this is a long test"
+ * Argument 1: [test]
+ * Argument 2: [this is a long test]
+ */
+#include <SimpleSerialShell.h>
+
+/**
+ * @brief Checks to see if a character is in a string.
+ *
+ * @param needle The character being searched for
+ * @param haystack null-delimited string
+ * @return true If found.
+ */
+static bool isIn(char needle, const char* haystack) {
+  const char* ptr = haystack;
+  while (*ptr != 0) {
+    if (needle == *ptr) {
+      return true;
+    }
+    ptr++;
+  }
+  return false;
+}
+
+/**
+ * @brief The tokenizer function that conforms to the SimpleSerialShell signature
+ * requirement.  Please see strtok_r(3) for an explanation of the expected semantics.
+ * 
+ * @param str 
+ * @param delims 
+ * @param saveptr 
+ * @return char* 
+ */
+static char* tokenizer(char* str, const char* delims, char** saveptr) {
+
+  // Figure out where to start scanning from
+  char* ptr = 0;
+  if (str == 0) {
+    ptr = *saveptr;
+  } else {
+    ptr = str;
+  }
+  
+  // Consume/ignore any leading delimiters
+  while (*ptr != 0 && isIn(*ptr, delims)) {
+    ptr++;
+  }
+
+  // At this point we either have a null or a non-delimiter
+  // character to deal with. If there is nothing left in the 
+  // string then return 0
+  if (*ptr == 0) {
+    return 0;
+  }
+
+  char* result;
+
+  // Check to see if this is a quoted token 
+  if (*ptr == '\"') {
+    // Skip the opening quote
+    ptr++;
+    // Result is the first eligible character
+    result = ptr;
+    while (*ptr != 0) {
+      if (*ptr == '\"') {
+        // Turn the trailing delimiter into a null-termination
+        *ptr = 0;
+        // Skip forward for next start
+        ptr++;
+        break;
+      } 
+      ptr++;
+    }
+  } 
+  else {
+    // Result is the first eligible character
+    result = ptr;
+    while (*ptr != 0) {
+      if (isIn(*ptr, delims)) {
+        // Turn the trailing delimiter into a null-termination
+        *ptr = 0;
+        // Skip forward for next start
+        ptr++;
+        break;
+      } 
+      ptr++;
+    }
+  }
+
+  // We will start on the next character when we return
+  *saveptr = ptr;
+  return result;
+}
+
+/**
+ * @brief Installed into the shell as a command processor.  Prints out the 
+ * arguments passed to the function.
+ * 
+ * @param argc 
+ * @param argv 
+ * @return int 
+ */
+int echo(int argc, char **argv) { 
+    for (int i = 1; i < argc; i++) {
+        shell.print("Argument ");
+        shell.print(i);
+        shell.print(": [");
+        shell.print(argv[i]);
+        shell.println("]");
+    }
+    return 0;
+}
+
+void setup() {
+    Serial.begin(115200);
+    shell.attach(Serial);
+    shell.addCommand(F("echo"), echo);
+    shell.setTokenizer(tokenizer);
+}
+
+void loop() {
+    shell.executeIfInput();
+}

--- a/extras/tests/CustomParserTest/CustomParserTest.ino
+++ b/extras/tests/CustomParserTest/CustomParserTest.ino
@@ -1,0 +1,126 @@
+// CustomParserTest.ino
+//
+#include <Arduino.h>
+
+// fake it for UnixHostDuino emulation
+#if defined(UNIX_HOST_DUINO)
+#  ifndef ARDUINO
+#  define ARDUINO 100
+#  endif
+#endif
+
+// These tests depend on the Arduino "AUnit" library
+#include <AUnit.h>
+#include "SimMonitor.h"
+#include <SimpleSerialShell.h>
+
+using namespace aunit;
+
+// some platforms ouput line endings differently.
+#define NEW_LINE "\r\n"
+//#define NEW_LINE "\n"
+
+// A mock of the Arduino Serial stream
+static SimMonitor terminal;
+
+void prepForTests(void)
+{
+    terminal.init();
+    shell.resetBuffer();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// test fixture to ensure clean initial and final conditions
+//
+class ShellTest: public TestOnce {
+    protected:
+        void setup() override {
+            TestOnce::setup();
+            prepForTests();
+        }
+
+        void teardown() override {
+            prepForTests();
+            TestOnce::teardown();
+        }
+};
+
+//////////////////////////////////////////////////////////////////////////////
+// A demonstration of the alternate tokenizer feature. 
+
+/**
+ * @brief Echoes the parameters of the function with comma-delimiting.
+ * @return int 0 On success, non-zero on error.
+ */
+int echo(int argc, char **argv) {
+    auto lastArg = argc - 1;
+    for ( int i = 1; i < argc; i++) {
+        shell.print(argv[i]);
+        if (i < lastArg)
+            shell.print(F(" "));
+    }
+    shell.println();
+    return 0;
+}
+
+/**
+ * @brief An alternate tokenizer that uses a comma-delimiter after the 
+ *   initial token has been identified.
+ */
+char* commaTokenizer(char* str, const char*, char** saveptr) {
+    // The first time we tokenize on space so that we can 
+    // pick up the command.  Subsequent calls we tokenize on 
+    // comma.
+    if (str != 0) {
+        return strtok_r(str, " ", saveptr);
+    } else {
+        return strtok_r(str, ",", saveptr);
+    }
+}
+
+testF(ShellTest, altTokenizer) {
+
+    const char* testCommand = "echo test1,test2,test3";
+
+    // Basic sanity check using the current semantics
+    terminal.pressKeys(testCommand);
+    assertFalse(shell.executeIfInput());
+    // Flush the user-entry
+    terminal.getline();
+    terminal.pressKey('\r');
+    assertTrue(shell.executeIfInput());
+    // Everything comes back as a single token
+    assertEqual(terminal.getline(),  (NEW_LINE "test1,test2,test3" NEW_LINE));
+
+    // Now plug in a new tokenizer that looks for commas instead of spaces.
+    // This is the main point of this unit test.
+    shell.setTokenizer(commaTokenizer);
+
+    // Send in the same command
+    terminal.pressKeys(testCommand);
+    assertFalse(shell.executeIfInput());
+    // Flush the user-entry
+    terminal.getline();
+    terminal.pressKey('\r');
+    assertTrue(shell.executeIfInput());
+    // Notice now that the three tokens were separated
+    assertEqual(terminal.getline(),  (NEW_LINE "test1 test2 test3" NEW_LINE));
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void setup() {
+    ::delay(1000); // wait for stability on some boards to prevent garbage Serial
+    Serial.begin(115200); // ESP8266 default of 74880 not supported on Linux
+    while (!Serial); // for the Arduino Leonardo/Micro only
+
+    shell.addCommand(F("echo"), echo);
+    shell.attach(terminal);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void loop() {
+    // Should get:
+    // TestRunner summary:
+    //   <n> passed, <n> failed, <n> skipped, <n> timed out, out of <n> test(s).
+    aunit::TestRunner::run();
+}

--- a/extras/tests/CustomParserTest/Makefile
+++ b/extras/tests/CustomParserTest/Makefile
@@ -6,7 +6,7 @@
 # point this will need ot be changed to:
 # include ../../../../EpoxyDuino/UnixHostDuino.mk
 #
-APP_NAME := simpleSerialShellTest
+APP_NAME := CustomParserTest
 ARDUINO_LIBS := AUnit SimpleSerialShell
 CPPFLAGS += -Werror
 include ../../../../EpoxyDuino/UnixHostDuino.mk

--- a/extras/tests/CustomParserTest/SimMonitor.cpp
+++ b/extras/tests/CustomParserTest/SimMonitor.cpp
@@ -1,0 +1,81 @@
+#include <Arduino.h>
+#include "SimMonitor.h"
+
+////////////////////////////////////////////////////////////////////////////////
+//
+SimMonitor::SimMonitor(void) {
+    init();
+}
+
+void SimMonitor::init(void) {
+    keyboardBuffer.flush();
+    displayBuffer.flush();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+String SimMonitor::getline(void) {
+    String theLine;
+    theLine.reserve(BUFSIZE);
+    while (displayBuffer.count() > 0) {
+        theLine += displayBuffer.dequeue();
+    }
+    return theLine;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// get a character sent to the display
+int SimMonitor::getOutput(void) {
+    int theKey = -1;
+    if (displayBuffer.count() > 0) {
+        theKey = displayBuffer.dequeue();
+    }
+    return theKey;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// simulate a keypress
+size_t SimMonitor::pressKey(char c) {
+    return keyboardBuffer.enqueue(c);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// simulate a bunch of keypresses
+size_t SimMonitor::pressKeys(const char * keys) {
+    size_t numSent = 0;
+
+    for (int i = 0; keys[i]; i++) {
+        numSent += pressKey(keys[i]);
+    }
+
+    return numSent;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+// stream interface
+size_t SimMonitor::write(uint8_t aByte) // write to "display"
+{
+    // carriage return should reset line?
+    return displayBuffer.enqueue(aByte);
+}
+
+int SimMonitor::available()     // any keypresses?
+{
+    return (keyboardBuffer.count() > 0);
+}
+
+int SimMonitor::read()          // read keyboard input
+{
+    return available() ? keyboardBuffer.dequeue() : -1;
+}
+
+int SimMonitor::peek()
+{
+    return available() ? keyboardBuffer.peek() : -1;
+}
+
+void SimMonitor::flush()
+{
+    init();
+}

--- a/extras/tests/CustomParserTest/SimMonitor.h
+++ b/extras/tests/CustomParserTest/SimMonitor.h
@@ -1,0 +1,32 @@
+#ifndef _SimMonitor_h
+#define _SimMonitor_h
+
+#include <Arduino.h>
+#include "../simpleSerialShellTest/simpleFIFO.h"
+
+// SimMonitor simulates a serial terminal
+class SimMonitor: public Stream {
+
+    public:
+        SimMonitor(void);
+        void init(void);
+        String getline(void); // get the line sent to display
+        int getOutput(void);  // get display output char, or -1 if none
+
+        size_t pressKeys(const char * s);  // send a line
+        size_t pressKey(char c);  // simulate a keypress
+
+        // stream emulation
+        virtual size_t write(uint8_t);
+        virtual int available();
+        virtual int read();
+        virtual int peek();
+        virtual void flush(); // esp32 needs an implementation
+
+    private:
+        static const int BUFSIZE = 80;
+        SimpleFIFO<char, BUFSIZE> keyboardBuffer;
+        SimpleFIFO<char, BUFSIZE> displayBuffer;
+};
+
+#endif

--- a/extras/tests/README.md
+++ b/extras/tests/README.md
@@ -1,0 +1,14 @@
+Notes on Unit Tests
+===================
+*  Be sure to clone the EpoxyDuino project (https://github.com/bxparks/EpoxyDuino) adjacent 
+to your SimpleSerialShell project.  
+*  Be sure to clone the AUnit project (https://github.com/bxparks/AUnit) adjacent 
+to your SimpleSerialShell project.  This is a dependency for unit testing.
+
+For example:
+```
+git clone https://github.com/bxparks/EpoxyDuino.git
+git clone https://github.com/bxparks/AUnit.git
+```
+
+

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SimpleSerialShell
-version=0.2.2
+version=0.2.3
 
 author=Phil Jansen
 maintainer=Phil Jansen

--- a/releaseChecklist.md
+++ b/releaseChecklist.md
@@ -1,0 +1,39 @@
+Release checklist:
+
+## "test" phase
+Confirm code changes all work together.
+
+- [ ] GitHub's automated build succeeds on all platforms (even platforms you don't have).
+  - This library is intended to work with many microcontrollers.  Your change should work for all of them. 
+  - If not, document what variants should expect.
+
+- [ ] Unit tests pass.
+  - [ ] Have you added tests to confirm new features continue to work (so nobody accidentally breaks your feature)?
+
+- [ ] Usage notes upated for new behaviors
+  - [ ] Does **README.md** need to describe new behavior?
+  - [ ] Any other documents need an upate?
+
+## "next" phase
+Prepare for release
+
+- [ ] Updated version number in **library.properties** file
+  - Is this a major release?
+
+- [ ] Updated **releaseNotes.md**
+  - What is the reason for this release?
+  - Is it obvious whether a developer needs this update, or can safely ignore it?
+
+## "release" phase
+Make the release visible to others
+
+- [ ] Code merged/squashed to **main**
+  - Clones of this library check out **main** by default.
+
+- [ ] Commit tagged with the new version number
+  - Arduino libraries only pick up tagged releases with a matching **library.properties** version, AND in the commit history for the **main** branch.
+
+- [ ] Confirm the new release is visible
+  - (It may take a day or so for the library managers to discover the new release)
+  - [ ] It should be visible in the Arduino IDE.
+  - Eventually it should be visible in the PlatformIO IDE. (hopefully this update is automatic)

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -1,5 +1,9 @@
 Release notes
 
+### v0.2.3
+* Support custom tokenizers, for example to quote text with spaces.
+* Clean up miscellaneous warnings
+
 ### v0.2.2
 examples/ArduinoTextInterface:
 * Provide memory dump commands for RAM, ROM and EEPROM address spaces.  Very useful for finding/removing constant strings in RAM.

--- a/src/SimpleSerialShell.cpp
+++ b/src/SimpleSerialShell.cpp
@@ -50,7 +50,8 @@ class SimpleSerialShell::Command {
 ////////////////////////////////////////////////////////////////////////////////
 SimpleSerialShell::SimpleSerialShell()
     : shellConnection(NULL),
-      m_lastErrNo(EXIT_SUCCESS)
+      m_lastErrNo(EXIT_SUCCESS),
+      tokenizer(strtok_r)
 {
     resetBuffer();
 
@@ -187,7 +188,7 @@ int SimpleSerialShell::execute(void)
 
     char * rest = NULL;
     const char * whitespace = " \t\r\n";
-    char * commandName = strtok_r(linebuffer, whitespace, &rest);
+    char * commandName = tokenizer(linebuffer, whitespace, &rest);
 
     if (!commandName)
     {
@@ -200,7 +201,7 @@ int SimpleSerialShell::execute(void)
 
     for ( ; argc < MAXARGS; )
     {
-        char * anArg = strtok_r(0, whitespace, &rest);
+        char * anArg = tokenizer(0, whitespace, &rest);
         if (anArg) {
             argv[argc++] = anArg;
         } else {
@@ -305,4 +306,9 @@ void SimpleSerialShell::flush()
 {
     if (shellConnection)
         shellConnection->flush();
+}
+
+void SimpleSerialShell::setTokenizer(TokenizerFunction f) 
+{
+    tokenizer = f;
 }

--- a/src/SimpleSerialShell.h
+++ b/src/SimpleSerialShell.h
@@ -51,6 +51,24 @@ class SimpleSerialShell : public Stream {
         virtual int peek();
         virtual void flush(); // esp32 needs an implementation
 
+        // The function signature of the tokening function.  This is based
+        // on the parameters of the strtok_r(3) function. 
+        // 
+        // Please keep these things in mind when creating your own tokenizer:
+        // * The str parameter is called the first time with the string to be 
+        //   tokenized, and then 0 is passed on subsequent calls.
+        // * The list of allowable delimiters can be changed on subsequent calls.
+        // * The str parameter is modified! 
+        // * saveptr should be treated as an opaque pointer.  Its meaning
+        //   is implementation-specific.
+        //
+        typedef char* (*TokenizerFunction)(char* str, const char* delim, char** saveptr);
+
+        // Call this to change the tokenizer function used internally.  By
+        // default strtok_r() is used, so the use of this funcition is 
+        // optional.
+        void setTokenizer(TokenizerFunction f);
+
     private:
         Stream * shellConnection;
         int m_lastErrNo;
@@ -66,6 +84,8 @@ class SimpleSerialShell : public Stream {
 
         class Command;
         static Command * firstCommand;
+
+        TokenizerFunction tokenizer;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* get rid of 'unused arg' warnings

* Pj/build cleanup (#8)

* build checks are more strict; clean up warnings

* ok that printHelp() has unused args

* more unused args are OK

* Pj/memory dump commands (#9)

* Add commands to dump memory (EEPROM, PROGMEM, RAM)
AVR microprocessors have 3 memory spaces
and unique access rules for each space

* SAMD51 does not support EEPROMs

* clean up for SAMD processors

* need one more ifdef for SAMD

* memory probe experiment was not for all platforms

* cast a esp8266 type conversion error

* update comment

* Move digital pinmode/read/write strings to PROGMEM.
Keeps const strings out of precious RAM space.

* Memory usage (#10)

* Provide memory usage summary without depending on library

* cleanup -- delete obsolete/distracting comments

* prep for v0.2.2 release

* Added the ability to install a custom tokenizer function.  This would be useful for applications that have command syntaxes that can't be parsed by the simple space-delimited format supported by strtok_r(3).

* test on pull_request; new EpoxyDuino lib name

* revert to using UnixHostDuino lib

* Switching back to UnixHostDuino per Phil's suggestion.  We can deal with this later.

* EpoxyDuino problem has been resolved sothe special comments about V1.0.0 have been removed.

* Test expecting different endline variants

* easier switch between "\r\n" and "\n" style outputs

* expect output lines to end with "\r\n"

* use renamed EpoxyDuino library

* Prepare for release/create release checklist

* Update releaseChecklist.md

more readable

* fix typos

Co-authored-by: Bruce MacKinnon <bruce@mackinnon.com>